### PR TITLE
Fix #30: display attachments from boosted toots

### DIFF
--- a/qml/lib/Worker.js
+++ b/qml/lib/Worker.js
@@ -252,5 +252,18 @@ function parseToot (data){
         }
         item['attachments'].push(tmp)
     }
+    if(item['status_reblog']){
+        for(var i = 0; i < data['reblog']['media_attachments'].length ; i++){
+            var attachments = data['reblog']['media_attachments'][i];
+            item['content'] = item['content'].replaceAll(attachments['text_url'], '')
+            var tmp = {
+                id: attachments['id'],
+                type: attachments['type'],
+                url: attachments['remote_url'] && typeof attachments['remote_url'] == "string" ? attachments['remote_url'] : attachments['url'],
+                preview_url: loadImages ? attachments['preview_url'] : ''
+            }
+            item['attachments'].push(tmp)
+        }
+    }
     return item;
 }


### PR DESCRIPTION
A 'boost' contains a copy of the source toot's text as its content, but it
doesn't copy the media_attachments. If the data['reblog'] field is not null,
append media_attachments from data['reblog'] as well as from data.