### PR TITLE
remove empty classes which causes some link texts to be rendered ugly

### DIFF
--- a/qml/lib/Worker.js
+++ b/qml/lib/Worker.js
@@ -239,7 +239,11 @@ function parseToot (data){
     } else {
         item = parseAccounts(item, "", data["account"])
     }
-    item['content'] = data['content'].replaceAll('</span><span class="invisible">', '').replaceAll('<span class="invisible">', '').replaceAll('</span><span class="ellipsis">', '');
+    item['content'] = data['content']
+        .replaceAll('</span><span class="invisible">', '')
+        .replaceAll('<span class="invisible">', '')
+        .replaceAll('</span><span class="ellipsis">', '')
+        .replaceAll('class=""', '');
     item['attachments'] = [];
 
 


### PR DESCRIPTION
Apparently removing an empty `class=""` suffices. Not sure it catches everything, but it's working:

Before the patch:

![before](https://user-images.githubusercontent.com/2184312/48518840-300b6d00-e86b-11e8-80e9-2f215c3e347e.png)

After the patch:

![after](https://user-images.githubusercontent.com/2184312/48518856-3699e480-e86b-11e8-8854-b9eb1c11e482.png)
